### PR TITLE
Allow admin

### DIFF
--- a/src/providers/lazy_auth.cpp
+++ b/src/providers/lazy_auth.cpp
@@ -89,8 +89,8 @@ User LazyAuth::checkAuth(std::string token){
         throw std::runtime_error("Error while authenticatin you: banned");
     }
 
-    // Only authorize Caen campus, for the moment.
-    if(info.HasMember("class_name") && info["class_name"].IsString()){
+    // Only authorize Caen campus, for the moment. (and admins obviously)
+    if(!is_admin && (info.HasMember("class_name") && info["class_name"].IsString())){
         std::string classname(info["class_name"].GetString());
 
         // look for the last " "


### PR DESCRIPTION
This pull request includes a change to the `LazyAuth::checkAuth` function in the `src/providers/lazy_auth.cpp` file. The change modifies the authorization logic to include an exception for admin users.

Authorization logic update:

* [`src/providers/lazy_auth.cpp`](diffhunk://#diff-0003ed83d6d7dbdb18f09a4dc1961ed0d1b4c6b7e22ce14b0ff5275a2156f099L92-R93): Updated the condition to check if the user is an admin before authorizing based on the `class_name` field. This allows admin users to bypass the class name authorization check.